### PR TITLE
rolex: Fix device manufacturer & model exif value

### DIFF
--- a/overlay/packages/apps/Snap/res/values/config.xml
+++ b/overlay/packages/apps/Snap/res/values/config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2012 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!-- Camera app resources that may need to be customized
+     for different hardware or product builds. -->
+<resources>
+    <!-- Set this to true to use device manufacturer and model for exif -->
+    <bool name="override_maker_and_model_tag">true</bool>
+</resources>


### PR DESCRIPTION
### Bug description:
Snap camera writes device manufacturer and model name as _QCOM-AA QCAM-AA_ for exif. In my case, the right value should be _Xiaomi Redmi 4A_.
<details><summary>Demo image</summary>

![Screenshot_20210314-192812_Galleria](https://user-images.githubusercontent.com/28353279/111164401-573eea00-859e-11eb-83b7-a55c77432b86.png)
</details>

These values are returned from camera HAL:
https://github.com/Wave-Project/device_xiaomi_rolex/blob/4da00de4703b134f362e365750e197d85c850daf/camera/QCamera2/HAL/QCamera2HWI.cpp#L9511-L9537

For some reason camera HAL couldn't access _build.prop_ values even though they are present:
```
$ adb shell getprop ro.product.manufacturer
* daemon not running; starting now at tcp:5037
* daemon started successfully
Xiaomi
$ adb shell getprop ro.product.model
Redmi 4A
```

### How to fix
It seems to be a common problem on some devices, so LineageOS offered a workaround according to [this](https://review.lineageos.org/c/LineageOS/android_packages_apps_Snap/+/233219/8) commit. I tried to unpack the Snap.apk and changed the value of `override_maker_and_model_tag` to `true`, then reassembled back and it works.
<details><summary>Demo image</summary>

![Screenshot_20210314-192827_Galleria](https://user-images.githubusercontent.com/28353279/111167229-2dd38d80-85a1-11eb-98b1-cf63735f6bc3.png)
</details>

<hr>

**P.S** check if this line won't cause problems:
https://github.com/Wave-Project/device_xiaomi_rolex/blob/4da00de4703b134f362e365750e197d85c850daf/device.mk#L25